### PR TITLE
Optimize size of tarballs and use browser-compatible brotli.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Deps
         run: |
           sudo apt update
-          sudo apt install -yy build-essential clang brotli
+          sudo apt install -yy build-essential clang brotli binaryen
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install wasmtime


### PR DESCRIPTION
 - Run wasm-opt to reduce executable sizes
 - Remove unneeded files from tarballs
